### PR TITLE
mark non-updated methods as "inactive"

### DIFF
--- a/app/models/doc_method.rb
+++ b/app/models/doc_method.rb
@@ -10,6 +10,10 @@ class DocMethod < ActiveRecord::Base
     where(doc_methods: {doc_comments_count: 0})
   end
 
+  def self.active
+    where(active: true)
+  end
+
   def self.with_docs
     where("doc_comments_count > 0")
   end

--- a/app/models/repo_subscription.rb
+++ b/app/models/repo_subscription.rb
@@ -28,6 +28,7 @@ class RepoSubscription < ActiveRecord::Base
 
   def unassigned_read_doc_methods(limit = self.read_limit)
     repo.methods_with_docs.
+         active.
          where("doc_methods.id not in (?)", pre_assigned_doc_method_ids).
          order("random()").
          limit(limit || DEFAULT_READ_LIMIT)
@@ -36,6 +37,7 @@ class RepoSubscription < ActiveRecord::Base
   def unassigned_write_doc_methods(limit = self.write_limit)
     doc_method_ids = self.doc_methods.map(&:id) + [-1]
     repo.methods_missing_docs.
+         active.
          where("doc_methods.id not in (?)", pre_assigned_doc_method_ids).
          where(skip_write: false).
          order("random()").

--- a/db/migrate/20140524105909_add_active_to_doc_methods.rb
+++ b/db/migrate/20140524105909_add_active_to_doc_methods.rb
@@ -1,0 +1,5 @@
+class AddActiveToDocMethods < ActiveRecord::Migration
+  def change
+    add_column :doc_methods, :active, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140507134638) do
+ActiveRecord::Schema.define(version: 20140524105909) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -64,6 +64,7 @@ ActiveRecord::Schema.define(version: 20140507134638) do
     t.string   "path"
     t.string   "file"
     t.boolean  "skip_write",         default: false
+    t.boolean  "active",             default: true
   end
 
   add_index "doc_methods", ["repo_id"], name: "index_doc_methods_on_repo_id", using: :btree

--- a/lib/tasks/schedule.rake
+++ b/lib/tasks/schedule.rake
@@ -6,7 +6,15 @@ namespace :schedule do
     end
   end
 
-  desc "sends all users an undocumented method or class of a repo they are following"
+  desc "Mark methods as 'inactive'"
+  task do
+    DocMethod.where(active: true).where("updated_at < '#{48.hours.ago}'").find_each do |m|
+      m.active = false
+      m.save
+    end
+  end
+
+  desc "sends all users a method or class of a repo they are following"
   task user_send_doc: :environment do
     User.find_each do |user|
       User.queue.subscribe_docs(user.id)


### PR DESCRIPTION
If we haven't parsed a method in over 48 hours, assume it no longer exists, mark it as "inactive".
