### PR TITLE
Adds 'skip_read' flag for comments only containing :nodoc:

### DIFF
--- a/app/models/repo_subscription.rb
+++ b/app/models/repo_subscription.rb
@@ -30,6 +30,7 @@ class RepoSubscription < ActiveRecord::Base
     repo.methods_with_docs.
          active.
          where("doc_methods.id not in (?)", pre_assigned_doc_method_ids).
+         where(skip_read: false).
          order("random()").
          limit(limit || DEFAULT_READ_LIMIT)
   end

--- a/db/migrate/20141202022842_add_skip_read_to_doc_methods.rb
+++ b/db/migrate/20141202022842_add_skip_read_to_doc_methods.rb
@@ -1,0 +1,5 @@
+class AddSkipReadToDocMethods < ActiveRecord::Migration
+  def change
+    add_column :doc_methods, :skip_read, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140524105909) do
+ActiveRecord::Schema.define(version: 20141202022842) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -65,6 +65,7 @@ ActiveRecord::Schema.define(version: 20140524105909) do
     t.string   "file"
     t.boolean  "skip_write",         default: false
     t.boolean  "active",             default: true
+    t.boolean  "skip_read",          default: false
   end
 
   add_index "doc_methods", ["repo_id"], name: "index_doc_methods_on_repo_id", using: :btree

--- a/lib/docs_doctor/parsers/ruby/yard.rb
+++ b/lib/docs_doctor/parsers/ruby/yard.rb
@@ -40,9 +40,10 @@ module DocsDoctor
             # document original method instead
             # don't document initialize
             skip_write = obj.is_attribute? || obj.is_alias? || (obj.respond_to?(:is_constructor?) && obj.is_constructor?)
+            skip_read = obj.docstring.strip.eql? ":nodoc:"
 
             method = repo.doc_methods.where(name: obj.name, path: obj.path).first_or_initialize
-            method.assign_attributes(line: obj.line, file: obj.file, skip_write: skip_write) # line and file will change, do not want to accidentally create duplicate methods
+            method.assign_attributes(line: obj.line, file: obj.file, skip_write: skip_write, skip_read: skip_read) # line and file will change, do not want to accidentally create duplicate methods
             unless method.save
               puts "Could not store YARD object, missing one or more properties: #{method.errors.inspect}"
               return false


### PR DESCRIPTION
- skip_read flag set by comments that eql ':nodoc:'
- prevents emails from being sent that encourage subscriber to read
  docs which are essentiall blank
- side effect that these docs won't be sent out for write either

addresses issue #9 
