### PR TITLE
Commenting out favourite language checkbox temporarily

### DIFF
--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -34,7 +34,7 @@
           <%- if user_signed_in? -%>
             <li><%= image_tag current_user.avatar_url, class: 'img-rounded', height: 30, width: 30 %></li>
             <li><%= link_to "Home", root_path %></li>
-            <li><%= link_to current_user.github, current_user %></li>
+            <li><%= link_to current_user.github, user_path(current_user) %></li>
             </li>
             <li><%= link_to "Sign Out", destroy_user_session_path, :method => :delete %></li>
           <%- else -%>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -27,6 +27,27 @@
       </dl>
     </section>
 
+    <section id="user-favorite-langs">
+      <h3>Favorite Languages:</h3>
+
+      <p>Select your favorite languages:</p>
+
+      <%= form_for @user do |f| %>
+
+        <%= hidden_field_tag "user[favorite_languages][]" %>
+        <% Repo.all_languages.each do |language| %>
+          <label class="checkbox">
+            <%# <%= f.check_box :favorite_languages, { multiple: true }, language, nil %1> %>
+            <%= language %>
+          </label>
+        <% end %>
+
+        <p>
+          <%= button_tag "Save", :class => "btn btn-primary" %>
+        </p>
+
+      <% end %>
+    </section>
   <% end %>
 
 </div>


### PR DESCRIPTION
Deployable quickfix for profiles.  Updated the link to users profile and commented out the favourite languages checkbox as it was breaking the page.  I don't know what the plan is for the profile page but it makes sense to have the other features of it accessible now.
