### PR TITLE
Fix user#edit form.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ActiveRecord::Base
          :recoverable, :rememberable, :trackable, :validatable, :omniauthable
 
   validates_uniqueness_of :email, allow_blank: true, :if => :email_changed?
-  validates_length_of     :password, within: 8..128
+  validates_length_of     :password, within: 8..128, allow_blank: true
 
   # Setup accessible (or protected) attributes for your model
   # attr_accessible :private, :email, :password, :password_confirmation, :remember_me, :zip, :phone_number, :twitter,

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -3,12 +3,8 @@
   <div class="input">
     <%= f.text_field :email, :class => 'text_field' %>
   </div>
-   <%= f.label :daily_issue_limit, t("activerecord.attributes.user.daily_issue_limit", :default => "Max # of issues you want to receive per day"), :class => :label %>
-  <div class="input">
-    <%= f.number_field :daily_issue_limit, :class => 'number_field' %>
-  </div>
-  <%= f.label :skip_issues_with_pr, t("activerecord.attributes.user.skip_issues_with_pr", :default => "Skip Issues with Pull requests"), :class => :label %>
-  <%= f.check_box :skip_issues_with_pr, :class => 'checkbox' %>
+  <%= f.label :private, t("activerecord.attributes.user.private", :default => "Make my account private"), :class => :label %>
+  <%= f.check_box :private, :class => 'checkbox' %>
 </div>
 
 <div class="form-actions">


### PR DESCRIPTION
Fixes #29 

The edit page was throwing error since `:daily_issue_limit` and `:skip_issues_with_pr` fields were not present on `user` model. I have made the edit page consistent with the `user#show` page with only two fields `email` and `private/public`.

Also the password-length validation failed while updating user since the password field was empty. So I put in a condition on the validation. 