### PR TITLE
Add commit sha to repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ parser.process
 parser.store(repo)
 # DocFile.destroy_all repo = Repo.last
 doc  = repo.methods_missing_docs.first
-GithubUrlFromBasePathLine.new(doc.repo.github_url, doc.doc_file.path, doc.line).to_github
+doc.to_github
 
 
 repo    = Repo.where(full_name: "rails/rails").first_or_create

--- a/app/models/doc_method.rb
+++ b/app/models/doc_method.rb
@@ -27,4 +27,9 @@ class DocMethod < ActiveRecord::Base
     absolute, match, relative = raw_file.partition(/(\/|^)#{repo.name}\//)
     return relative
   end
+
+  # converts a doc method to a github path
+  def to_github
+    GithubUrlFromBasePathLine.new(repo.github_url, repo.commit_sha, file, line).to_github
+  end
 end

--- a/app/models/github_fetcher.rb
+++ b/app/models/github_fetcher.rb
@@ -10,6 +10,10 @@ class GithubFetcher
     return dir
   end
 
+  def commit_sha
+    ::GitHubBub.get(File.join(repo_path, 'commits', repo_json['default_branch'])).json_body['sha']
+  end
+
   def dir
     @dir ||= Dir.mktmpdir
   end

--- a/app/models/github_url_from_base_path_line.rb
+++ b/app/models/github_url_from_base_path_line.rb
@@ -1,13 +1,14 @@
 class GithubUrlFromBasePathLine
 
-  def initialize(base, path, line)
+  def initialize(base, commit_sha, path, line)
     @base = base
+    @commit_sha = commit_sha
     @line = line
     @path = path
   end
 
-  # https://github.com/rails/rails/blob/master/actionmailer/lib/action_mailer/collector.rb#L10
+  # https://github.com/codetriage/docs_doctor/blob/f5dd91595d5cdad0a2348515c6f715ef19c51070/app/models/github_url_from_base_path_line.rb#L10
   def to_github
-    File.join(@base, "blob/master", @path, "#L#{@line}")
+    File.join(@base, 'blob', @commit_sha, @path, "#L#{@line}")
   end
 end

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -22,6 +22,7 @@ class Repo < ActiveRecord::Base
 
   def process!
     fetcher = GithubFetcher.new(full_name)
+    self.update!(commit_sha: fetcher.commit_sha)
     parser  = DocsDoctor::Parsers::Ruby::Yard.new(fetcher.clone)
     parser.process
     parser.store(self)

--- a/app/views/doc_methods/show.html.erb
+++ b/app/views/doc_methods/show.html.erb
@@ -1,4 +1,4 @@
-<h2><%= link_to @doc.path, GithubUrlFromBasePathLine.new(@doc.repo.github_url, @doc.file, @doc.line).to_github %></h2>
+<h2><%= link_to @doc.path, @doc.to_github %></h2>
 <p><%= link_to @doc.repo.full_name, @doc.repo %></p>
 
 <h3>Docs:</h3>
@@ -11,7 +11,7 @@
   <% end %>
 </p>
 <p>
-  <%= link_to "Source", GithubUrlFromBasePathLine.new(@doc.repo.github_url, @doc.file, @doc.line).to_github %> |
+  <%= link_to "Source", @doc.to_github %> |
   <%= link_to "Google", "https://www.google.com/search?q=#{URI.encode(@doc.path)}" %> |
   <%= link_to "Stack overflow", "http://stackoverflow.com/search?q=#{URI.encode(@doc.path)}" %>
 </p>

--- a/app/views/user_mailer/daily_docs.md.erb
+++ b/app/views/user_mailer/daily_docs.md.erb
@@ -4,7 +4,7 @@ Hi @<%= @user.github %>,
 ## Write Docs
 
 <% @write_docs.sort_by {|d| d.repo.full_name }.each do |doc| %>
-**<%= doc.repo.full_name %>** ([source](<%= GithubUrlFromBasePathLine.new(doc.repo.github_url, doc.file, doc.line).to_github %>)): [<%= doc.path %>](<%= doc_method_url doc %>)
+**<%= doc.repo.full_name %>** ([source](<%= doc.to_github %>)): [<%= doc.path %>](<%= doc_method_url doc %>)
 
 <% end %>
 <% end %>
@@ -15,7 +15,7 @@ Hi @<%= @user.github %>,
 ## Read Docs
 
 <% @read_docs.sort_by {|d| d.repo.full_name }.each do |doc| %>
-**<%= doc.repo.full_name %>** ([source](<%= GithubUrlFromBasePathLine.new(doc.repo.github_url, doc.file, doc.line).to_github %>)): [<%= doc.path %>](<%= doc_method_url doc %>)
+**<%= doc.repo.full_name %>** ([source](<%= doc.to_github %>)): [<%= doc.path %>](<%= doc_method_url doc %>)
 
 <pre>
 <%= doc.doc_comments.first.try(:comment) %>

--- a/db/migrate/20151123190940_add_commit_sha_to_repo.rb
+++ b/db/migrate/20151123190940_add_commit_sha_to_repo.rb
@@ -1,0 +1,5 @@
+class AddCommitShaToRepo < ActiveRecord::Migration
+  def change
+    add_column :repos, :commit_sha, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141202022842) do
+ActiveRecord::Schema.define(version: 20151123190940) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -97,6 +97,7 @@ ActiveRecord::Schema.define(version: 20141202022842) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "excluded"
+    t.string   "commit_sha"
   end
 
   create_table "users", force: true do |t|

--- a/test/fixtures/repos.yml
+++ b/test/fixtures/repos.yml
@@ -7,6 +7,7 @@ issue_triage_sandbox:
   created_at: 2012-11-10 21:50:48.351554000 Z
   updated_at: 2012-11-10 21:50:48.351554000 Z
   issues_count: 1
+  commit_sha: e01441fedcf95651acc6b7690e1f35857a74b449
 
 rails_rails:
   id: 2
@@ -17,6 +18,7 @@ rails_rails:
   created_at: 2012-11-10 21:50:48.351554000 Z
   updated_at: 2012-11-10 21:50:48.351554000 Z
   issues_count: 0
+  commit_sha: 14314ca18302f18c3d8bb7a63e9f71ac4c2290c2
 
 sinatra_sinatra:
   id: 3
@@ -27,6 +29,7 @@ sinatra_sinatra:
   created_at: 2012-11-10 21:50:48.351554000 Z
   updated_at: 2012-11-10 21:50:48.351554000 Z
   issues_count: 1
+  commit_sha: fabf8efc451f361c444b288eb94292593f340f77
 
 node:
   id: 4
@@ -37,6 +40,7 @@ node:
   created_at: 2012-11-10 21:50:48.351554000 Z
   updated_at: 2012-11-10 21:50:48.351554000 Z
   issues_count: 0
+  commit_sha: ed0d1c384cd4578f7168633c838f1252bddb260e
 
 groovebasin:
   id: 5
@@ -47,8 +51,7 @@ groovebasin:
   created_at: 2012-11-10 21:50:48.351554000 Z
   updated_at: 2012-11-10 21:50:48.351554000 Z
   issues_count: 1
-
-
+  commit_sha: 3a61986931d95ab1d1d2080e678907f029750573
 
 threaded:
   id: 6
@@ -59,3 +62,4 @@ threaded:
   created_at: 2012-11-10 21:50:48.351554000 Z
   updated_at: 2012-11-10 21:50:48.351554000 Z
   issues_count: 1
+  commit_sha: c55e2cd91c038ef6924988ed6f53e8c77eb59246


### PR DESCRIPTION
Store the commit sha of the time the repo was last processed. Ensures the emails point to the correct location in source. Fixes issue #39.