### PR TITLE
change rvm ruby version to 2.3 in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: ruby
 rvm:
-- 2.2.0
+- ruby-2.3.0-preview1
 script:
 - RAILS_ENV=test bundle exec rake --trace db:create db:migrate test
 deploy:


### PR DESCRIPTION
Fixes the travis build by installing ruby-2.3.0-preview1 with rvm.
