### PR TITLE
Fix rake command in Travis config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: ruby
 rvm:
 - 2.3.0
 script:
-- RAILS_ENV=test bundle exec rake --trace db:create db:migrate test
+- RAILS_ENV=test bundle exec rake db:create db:migrate test -- --trace
 deploy:
   provider: heroku
   api_key:


### PR DESCRIPTION
The Travis build on master has been failing since fdb029200418c0c8cb38be2da447f5054c7eb4dd was merged. It looks like one of the new gem versions changed their command line option parsing and the `--trace` option was being applied to something other than rake (https://travis-ci.org/codetriage/docs_doctor/builds/115344430). This PR fixes the build command to apply the `--trace` option to rake.

This unfortunately does not fix the build, because now that the tests are running there are several test failures.