### PR TITLE
Fix generated repo paths to not encode '/'.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,7 @@ DocsDoctorWeb::Application.routes.draw do
   scope format: false do
     resources :repos, only: %w[index new create]
 
-    scope ':full_name' do
+    scope '*full_name' do
       constraints full_name: %r{[-_.a-zA-Z0-9]+/[-_.a-zA-Z0-9]+} do
         get '/',            to: 'repos#show',        as: 'repo'
         put '/',            to: 'repos#update',      as:  nil


### PR DESCRIPTION
A fix for #50.

This is caused by rails/rails#16058, apparently an intentional behavior change. Seeing that and your comment in #50:

> The routes are basically the same as codetriage.com and that works fine

Led me to look at it's routes; Codetriage's routes use the globbing mentioned in the rails ticket above, while DocsDoctor's did not: https://github.com/codetriage/codetriage/blob/master/config/routes.rb#L47

I'm not sure how I'd go about writing a test for this, but I can verify this works at least from the rails console:

```
2.3.0 :005 >   url_helpers = Rails.application.routes.url_helpers
 => #<Module:0x00000002f9f888> 
2.3.0 :006 > repo = Repo.last
  Repo Load (0.6ms)  SELECT  "repos".* FROM "repos"  ORDER BY "repos"."id" DESC LIMIT 1
 => #<Repo id: 3, name: "bell", user_name: "taco", issues_count: 0, language: nil, description: nil, full_name: "taco/bell", notes: nil, created_at: "2016-03-17 08:34:59", updated_at: "2016-03-17 08:34:59", excluded: nil, commit_sha: nil> 
2.3.0 :007 > # On master
2.3.0 :008 >   url_helpers.repo_path(repo)
 => "/taco%2Fbell" 
2.3.0 :009 > # Switching to the fixed branch
2.3.0 :010 >   reload!
Reloading...
 => true 
2.3.0 :011 > url_helpers.repo_path(repo)
 => "/taco/bell" 
```